### PR TITLE
Added selectCodes option for SSB API

### DIFF
--- a/src/Altinn.Codelists/SSB/ClassificationCodelistProvider.cs
+++ b/src/Altinn.Codelists/SSB/ClassificationCodelistProvider.cs
@@ -62,7 +62,7 @@ public class ClassificationCodelistProvider : IAppOptionsProvider
         string variant = mergedKeyValuePairs.GetValueOrDefault("variant") ?? string.Empty;
         string selectCodes = mergedKeyValuePairs.GetValueOrDefault("selectcodes") ?? string.Empty;
 
-        var classificationCode = await _classificationsClient.GetClassificationCodes(_classificationId, language, dateOnly, level, variant,selectCodes);
+        var classificationCode = await _classificationsClient.GetClassificationCodes(_classificationId, language, dateOnly, level, variant, selectCodes);
 
         string parentCode = mergedKeyValuePairs.GetValueOrDefault("parentCode") ?? string.Empty;
 

--- a/src/Altinn.Codelists/SSB/ClassificationCodelistProvider.cs
+++ b/src/Altinn.Codelists/SSB/ClassificationCodelistProvider.cs
@@ -60,8 +60,9 @@ public class ClassificationCodelistProvider : IAppOptionsProvider
         DateOnly dateOnly = date == null ? DateOnly.FromDateTime(DateTime.Today) : DateOnly.Parse(date);
         string level = mergedKeyValuePairs.GetValueOrDefault("level") ?? string.Empty;
         string variant = mergedKeyValuePairs.GetValueOrDefault("variant") ?? string.Empty;
+        string selectCodes = mergedKeyValuePairs.GetValueOrDefault("selectcodes") ?? string.Empty;
 
-        var classificationCode = await _classificationsClient.GetClassificationCodes(_classificationId, language, dateOnly, level, variant);
+        var classificationCode = await _classificationsClient.GetClassificationCodes(_classificationId, language, dateOnly, level, variant,selectCodes);
 
         string parentCode = mergedKeyValuePairs.GetValueOrDefault("parentCode") ?? string.Empty;
 

--- a/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
+++ b/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
@@ -33,7 +33,7 @@ public class ClassificationsHttpClient : IClassificationsClient
     /// <param name="variant">The name of the variant to use instead of the original code list specified.</param>
     /// <param name="selectCodes">selectCodes is used to limit the result to codes that match the pattern given by selectCodes.</param>
     /// <returns></returns>
-    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "",string selectCodes = "")
+    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes = "")
     {
         string selectLanguage = $"language={language}";
 
@@ -56,7 +56,7 @@ public class ClassificationsHttpClient : IClassificationsClient
         {
             url = $"{classificationId}/variantAt";
         }
-        string query = BuildQuery(selectLanguage, selectDate, selectLevel, selectVariant,selectedCodes);
+        string query = BuildQuery(selectLanguage, selectDate, selectLevel, selectVariant, selectedCodes);
 
         var response = await _httpClient.GetAsync($"{url}{query}");
 

--- a/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
+++ b/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
@@ -31,8 +31,9 @@ public class ClassificationsHttpClient : IClassificationsClient
     /// <param name="atDate">The date the classification should be valid</param>
     /// <param name="level">The hierarchy level for classifications with multiple levels. Defaults to empty string, ie. all levels.</param>
     /// <param name="variant">The name of the variant to use instead of the original code list specified.</param>
+    /// <param name="selectCodes">selectCodes is used to limit the result to codes that match the pattern given by selectCodes.</param>
     /// <returns></returns>
-    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language="nb", DateOnly? atDate = null, string level = "", string variant = "")
+    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language="nb", DateOnly? atDate = null, string level = "", string variant = "",string selectCodes="")
     {
         string selectLanguage = $"language={language}";
 
@@ -46,13 +47,16 @@ public class ClassificationsHttpClient : IClassificationsClient
         // Variants are referenced by name
         string selectVariant = variant.IsNullOrEmpty() ? string.Empty : $"&variantName={variant}";
 
+        //SelectCodes
+        string selectedCodes = selectCodes.IsNullOrEmpty() ? string.Empty : $"&selectCodes={selectCodes}";
+
         // Start of url differs depending on if we are getting codes or variants
         string url = $"{classificationId}/codesAt";
         if (!variant.IsNullOrEmpty())
         {
             url = $"{classificationId}/variantAt";
         }
-        string query = BuildQuery(selectLanguage, selectDate, selectLevel, selectVariant);
+        string query = BuildQuery(selectLanguage, selectDate, selectLevel, selectVariant,selectedCodes);
 
         var response = await _httpClient.GetAsync($"{url}{query}");
 
@@ -65,7 +69,7 @@ public class ClassificationsHttpClient : IClassificationsClient
         // If we get a 404 we try to get the codes in the fallback language (nb)
         else if (response.StatusCode == HttpStatusCode.NotFound && language != "nb")
         {
-            string fallbackQuery = BuildQuery("language=nb", selectDate, selectLevel, selectVariant);
+            string fallbackQuery = BuildQuery("language=nb", selectDate, selectLevel, selectVariant,selectedCodes);
             var fallbackResponse = await _httpClient.GetAsync($"{url}{fallbackQuery}");
             if (fallbackResponse.IsSuccessStatusCode)
             {
@@ -78,8 +82,8 @@ public class ClassificationsHttpClient : IClassificationsClient
         return new ClassificationCodes();
     }
 
-    private static string BuildQuery(string selectLanguage, string selectDate, string selectLevel, string selectVariant)
+    private static string BuildQuery(string selectLanguage, string selectDate, string selectLevel, string selectVariant, string selectCodes)
     {
-        return $"?{selectLanguage}{selectDate}{selectLevel}{selectVariant}";
+        return $"?{selectLanguage}{selectDate}{selectLevel}{selectVariant}{selectCodes}";
     }
 }

--- a/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
+++ b/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClient.cs
@@ -33,7 +33,7 @@ public class ClassificationsHttpClient : IClassificationsClient
     /// <param name="variant">The name of the variant to use instead of the original code list specified.</param>
     /// <param name="selectCodes">selectCodes is used to limit the result to codes that match the pattern given by selectCodes.</param>
     /// <returns></returns>
-    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language="nb", DateOnly? atDate = null, string level = "", string variant = "",string selectCodes="")
+    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "",string selectCodes = "")
     {
         string selectLanguage = $"language={language}";
 

--- a/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClientCached.cs
+++ b/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClientCached.cs
@@ -35,13 +35,13 @@ namespace Altinn.Codelists.SSB.Clients
         /// <inheritdoc/>
         public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes = "")
         {
-            var cacheKey = GetCacheKey(classificationId, language, atDate, level, variant,selectCodes);
+            var cacheKey = GetCacheKey(classificationId, language, atDate, level, variant, selectCodes);
 
             var codes = await _memoryCache.GetOrCreateAsync(cacheKey, async cacheEntry =>
             {
                 var cacheEntryOptions = _getCacheEntryOptions.Invoke();
                 cacheEntry.SetOptions(cacheEntryOptions);
-                var data = await _classificationsClient.GetClassificationCodes(classificationId, language, atDate, level, variant,selectCodes);
+                var data = await _classificationsClient.GetClassificationCodes(classificationId, language, atDate, level, variant, selectCodes);
 
                 if (data is null)
                 {

--- a/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClientCached.cs
+++ b/src/Altinn.Codelists/SSB/Clients/ClassificationsHttpClientCached.cs
@@ -33,15 +33,15 @@ namespace Altinn.Codelists.SSB.Clients
         }
 
         /// <inheritdoc/>
-        public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "")
+        public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes = "")
         {
-            var cacheKey = GetCacheKey(classificationId, language, atDate, level, variant);
+            var cacheKey = GetCacheKey(classificationId, language, atDate, level, variant,selectCodes);
 
             var codes = await _memoryCache.GetOrCreateAsync(cacheKey, async cacheEntry =>
             {
                 var cacheEntryOptions = _getCacheEntryOptions.Invoke();
                 cacheEntry.SetOptions(cacheEntryOptions);
-                var data = await _classificationsClient.GetClassificationCodes(classificationId, language, atDate, level, variant);
+                var data = await _classificationsClient.GetClassificationCodes(classificationId, language, atDate, level, variant,selectCodes);
 
                 if (data is null)
                 {
@@ -55,9 +55,9 @@ namespace Altinn.Codelists.SSB.Clients
             return codes ?? new ClassificationCodes() { Codes = new List<ClassificationCode>() };
         }
 
-        private static string GetCacheKey(int classificationId, string language, DateOnly? atDate, string level, string variant)
+        private static string GetCacheKey(int classificationId, string language, DateOnly? atDate, string level, string variant, string selectCodes)
         {
-            return $"{classificationId}_{language}_{atDate?.ToString("yyyy-MM-dd")}_{level}_{variant}";
+            return $"{classificationId}_{language}_{atDate?.ToString("yyyy-MM-dd")}_{level}_{variant}_{selectCodes}";
         }
 
         // Expires the cache entry at midnight, to get potential new or removed entries.

--- a/src/Altinn.Codelists/SSB/IClassificationsClient.cs
+++ b/src/Altinn.Codelists/SSB/IClassificationsClient.cs
@@ -10,6 +10,6 @@ namespace Altinn.Codelists.SSB
         /// <summary>
         /// Gets the codes for the specified classification. If no date is specified, the current date is used.
         /// </summary>
-        Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "");
+        Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes = "");
     }
 }

--- a/test/Altinn.Codelists.Tests/SSB/Mocks/ClassificationsHttpClientMock.cs
+++ b/test/Altinn.Codelists.Tests/SSB/Mocks/ClassificationsHttpClientMock.cs
@@ -68,9 +68,9 @@ public class ClassificationsHttpClientMock : IClassificationsClient
         _client = new ClassificationsHttpClient(_options, new HttpClient(HttpMessageHandlerMock));
     }
 
-    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "")
+    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes="")
     {
-        ClassificationCodes classificationCodes = await _client.GetClassificationCodes(classificationId, language, atDate, level, variant);
+        ClassificationCodes classificationCodes = await _client.GetClassificationCodes(classificationId, language, atDate, level, variant, selectCodes);
 
         return level == string.Empty
             ? classificationCodes

--- a/test/Altinn.Codelists.Tests/SSB/Mocks/ClassificationsHttpClientMock.cs
+++ b/test/Altinn.Codelists.Tests/SSB/Mocks/ClassificationsHttpClientMock.cs
@@ -68,7 +68,7 @@ public class ClassificationsHttpClientMock : IClassificationsClient
         _client = new ClassificationsHttpClient(_options, new HttpClient(HttpMessageHandlerMock));
     }
 
-    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes="")
+    public async Task<ClassificationCodes> GetClassificationCodes(int classificationId, string language = "nb", DateOnly? atDate = null, string level = "", string variant = "", string selectCodes = "")
     {
         ClassificationCodes classificationCodes = await _client.GetClassificationCodes(classificationId, language, atDate, level, variant, selectCodes);
 


### PR DESCRIPTION
## Description
Added selectCodes option for SSB API.
selectCodes is used to limit the result to codes that match the pattern given by selectCodes.

https://data.ssb.no/api/klass/v1/api-guide.html#_selectcodes

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [] All tests run green

